### PR TITLE
TLS encryption with Let's Encrypt and cert-manager

### DIFF
--- a/cluster/base/argocd/certificate.yaml
+++ b/cluster/base/argocd/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-tls-cert
+  namespace: argocd
+spec:
+  secretName: argocd-tls
+  dnsNames:
+    - "argocd.cis240470.projects.jetstream-cloud.org"
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer

--- a/cluster/base/argocd/ingress.yaml
+++ b/cluster/base/argocd/ingress.yaml
@@ -20,3 +20,5 @@ spec:
         - name: argocd-server
           port: 80
           scheme: h2c
+  tls:
+    secretName: argocd-tls

--- a/cluster/base/argocd/kustomization.yaml
+++ b/cluster/base/argocd/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - namespace.yaml
 - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 - ingress.yaml
+- certificate.yaml
 
 patchesStrategicMerge:
 - cmd-commands-cm.yaml

--- a/cluster/base/cert-manager/issuer-staging.yaml
+++ b/cluster/base/cert-manager/issuer-staging.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # Production server is on https://acme-v02.api.letsencrypt.org/directory
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik

--- a/cluster/base/headlamp/certificate.yaml
+++ b/cluster/base/headlamp/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: headlamp-tls-cert
+  namespace: kube-system
+spec:
+  secretName: headlamp-tls
+  dnsNames:
+    - "dashboard.cis240470.projects.jetstream-cloud.org"
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer

--- a/cluster/base/headlamp/ingress.yaml
+++ b/cluster/base/headlamp/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
 spec:
   entryPoints:
-    - web
+    - websecure
   routes:
     - kind: Rule
       match: Host(`dashboard.cis240470.projects.jetstream-cloud.org`)
@@ -13,3 +13,5 @@ spec:
       services:
         - name: headlamp
           port: 80
+  tls:
+    secretName: headlamp-tls

--- a/cluster/base/headlamp/ingress.yaml
+++ b/cluster/base/headlamp/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
 spec:
   entryPoints:
-    - websecure
+    - web
   routes:
     - kind: Rule
       match: Host(`dashboard.cis240470.projects.jetstream-cloud.org`)
@@ -13,5 +13,3 @@ spec:
       services:
         - name: headlamp
           port: 80
-  tls:
-    secretName: headlamp-tls

--- a/cluster/base/headlamp/kustomization.yaml
+++ b/cluster/base/headlamp/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: kube-system
 resources:
 - https://raw.githubusercontent.com/kinvolk/headlamp/main/kubernetes-headlamp.yaml
 - ingress.yaml
+- certificate.yaml

--- a/cluster/base/traefik/certificate.yaml
+++ b/cluster/base/traefik/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: traefik-dashboard-cert
+  namespace: kube-system
+spec:
+  secretName: traefik-dashboard-tls
+  dnsNames:
+    - "argocd.cis240470.projects.jetstream-cloud.org"
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer

--- a/cluster/base/traefik/dashboard-ingress.yaml
+++ b/cluster/base/traefik/dashboard-ingress.yaml
@@ -3,9 +3,13 @@ kind: IngressRoute
 metadata:
   name: traefik-dashboard
 spec:
+  entryPoints:
+    - websecure
   routes:
   - match: Host("traefik.cis240470.projects.jetstream-cloud.org") && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
     kind: Rule
     services:
     - name: api@internal
       kind: TraefikService
+  tls:
+    secretName: traefik-dashboard-tls

--- a/cluster/base/traefik/kustomization.yaml
+++ b/cluster/base/traefik/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: kube-system
 resources:
 - dashboard.yaml
 - dashboard-ingress.yaml
+- certificate.yaml

--- a/scripts/setup-k3s-head.sh
+++ b/scripts/setup-k3s-head.sh
@@ -29,6 +29,11 @@ kubectl patch node "$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
 kubectl create secret -n kube-system generic cloud-config --from-file=/tmp/cluster/base/openstack/cloud.conf || true
 kubectl apply -k /tmp/cluster/base/openstack
 
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.0/cert-manager.yaml
+echo "Waiting for cert-manager webhook to be ready..."
+kubectl wait --for=condition=ready pod -l app=webhook -n cert-manager --timeout=120s
+kubectl apply -f /tmp/cluster/base/cert-manager/issuer-staging.yaml
+
 echo "Waiting for Traefik to be ready..."
 until kubectl get svc -n kube-system traefik &>/dev/null; do
   sleep 2
@@ -59,7 +64,6 @@ until kubectl get svc -n argocd-server &>/dev/null; do
   sleep 2
 done
 
-
 # Install OpenStack CLI
 sudo apt-get update && sudo apt-get install python3-designateclient python3-openstackclient -y
 
@@ -87,9 +91,9 @@ export OS_USER_DOMAIN_NAME=access
 ## Assign DNS records to the load balancer IP
 DOMAIN=cis240470.projects.jetstream-cloud.org
 
-openstack recordset create --type A --record "$IP" $DOMAIN. argocd || true
-openstack recordset create --type A --record "$IP" $DOMAIN. traefik || true
-openstack recordset create --type A --record "$IP" $DOMAIN. dashboard || true
+openstack recordset create --type A --record "$IP" $DOMAIN. argocd
+openstack recordset create --type A --record "$IP" $DOMAIN. traefik
+openstack recordset create --type A --record "$IP" $DOMAIN. dashboard
 
 # The trailing slash is important for the Traefik dashboard URL IngressRoute
 echo "Traefik dashboard is available at http://traefik.$DOMAIN/dashboard/"

--- a/terraform/modules/k3s/server/main.ts
+++ b/terraform/modules/k3s/server/main.ts
@@ -21,7 +21,7 @@ export class K3sServerModule extends Construct {
         super(scope, id);
 
         const { DEFAULT_IMAGE_NAME, Security } = props;
-        const K3S_HEAD_FLAVOR_NAME = props.K3S_HEAD_FLAVOR_NAME || "m3.small";
+        const K3S_HEAD_FLAVOR_NAME = props.K3S_HEAD_FLAVOR_NAME || "m3.medium";
 
         const k3sHeadKeyPair = new ComputeKeypairV2(this, `k3s-head-keypair`, {
             name: `k3s-head-keypair`,


### PR DESCRIPTION
# PR
- installs cert-manager
- configures a ClusterIssuer from Let's Encrypt
- enables TLS on all services
- Closes #2 

**Note:** Let's Encrypt production servers have a very strict ratelimit, so until our cluster is confidently stable (eg no more teardowns), no actual certs will be issued (although TLS is still used via self-signed certs).